### PR TITLE
Add health script that checks certificate expiration. Always overwrit…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ USER root
 
 # Install dependencies
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y python3-pip
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y python3-pip curl
 
 # Upgrade pip and setuptools
 RUN python3 -m pip install -U pip setuptools

--- a/jenkins-files/planetway/artifacts/tools/health.sh
+++ b/jenkins-files/planetway/artifacts/tools/health.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eux
+
+persistent_datastore="${PERSISTENT_DATASTORE:-/opt/persistent_datastore}"
+server_truststore_password="${SERVER_TRUSTSTORE_PASSWORD:-changeit}"
+server_name="${SERVER_NAME:-localhost}"
+server_keystore_path="${SERVER_KEYSTORE_PATH:-${persistent_datastore}/server.jks}"
+server_keystore_password="${SERVER_KEYSTORE_PASSWORD:-secret}"
+
+# Fail if the certificate will expire in 24h
+keytool -export -keystore $server_keystore_path -alias $server_name -rfc -protected | openssl x509 -checkend 86400 -noout
+
+curl -sf http://localhost:8080/ejbca

--- a/jenkins-files/planetway/artifacts/tools/libs/common_libs.sh
+++ b/jenkins-files/planetway/artifacts/tools/libs/common_libs.sh
@@ -37,19 +37,17 @@ function convert_p12_to_jks () {
   local jks_path=$5
   local jks_password=$6
   
-  if [[ ! -f $jks_path ]]; then
-    openssl pkcs12  -export -in $cert -inkey $key -name $alias \
-                    -out /tmp/keystore.p12 \
-                    -passin pass:${key_password} -passout pass:${key_password}
+  openssl pkcs12  -export -in $cert -inkey $key -name $alias \
+                  -out /tmp/keystore.p12 \
+                  -passin pass:${key_password} -passout pass:${key_password}
 
-    keytool -importkeystore -noprompt \
-            -srckeystore /tmp/keystore.p12 \
-            -srcstorepass $key_password \
-            -destkeystore $jks_path \
-            -deststorepass $jks_password \
-            -deststoretype jks
-    rm /tmp/keystore.p12
-  fi
+  keytool -importkeystore -noprompt \
+          -srckeystore /tmp/keystore.p12 \
+          -srcstorepass $key_password \
+          -destkeystore $jks_path \
+          -deststorepass $jks_password \
+          -deststoretype jks
+  rm /tmp/keystore.p12
 }
 
 function retry_while() {


### PR DESCRIPTION
Always convert cert to jks. (don't check if file exists.).

Also add a health script that checks localhost:8080/ejbca and the certificate expiration, to be used by k8s liveness probe. This is so that when the certificate is updated by aws-acm-issuer, the certificate is automatically loaded as well.